### PR TITLE
Remove webserver13 from list of all servers

### DIFF
--- a/servers.ini
+++ b/servers.ini
@@ -48,7 +48,6 @@ webserver9
 webserver10
 webserver11
 webserver12
-webserver13
 webserver14
 discourse
 


### PR DESCRIPTION
webserver13 is the d-portal server and so should be treated differently to the others (primarily at this point, more people require access to it).

As a stop-gap measure, it is being removed from the list of all servers. A more permanent solution can be determined in the future.