### PR TITLE
Wagtail alpha

### DIFF
--- a/roles/wagtail/wagtail_setup/tasks/django_postgres_setup.yml
+++ b/roles/wagtail/wagtail_setup/tasks/django_postgres_setup.yml
@@ -5,9 +5,13 @@
     privs: ALL
     type: database
     roles: "{{ db_user }}"
+  become: true
+  become_user: postgres
 
 - name: Update database user with database password
   postgresql_user:
     name: "{{ db_user }}"
     db: "{{ custom_database_name }}"
     password: "{{ db_password }}"
+  become: true
+  become_user: postgres

--- a/roles/wagtail/wagtail_setup/tasks/django_setup.yml
+++ b/roles/wagtail/wagtail_setup/tasks/django_setup.yml
@@ -1,7 +1,19 @@
 ---
-- name: Run migrate to update the database based on the app models
+- name: Run makemigrations_translation to create any new migrations since last update
   django_manage:
-    command: migrate
+    command: makemigrations_translation
+    app_path: "{{ django_dir }}"
+    virtualenv: "{{ virtualenv_path }}"
+
+- name: Run migrate_translation to update the database based on the app models
+  django_manage:
+    command: migrate_translation --noinput
+    app_path: "{{ django_dir }}"
+    virtualenv: "{{ virtualenv_path }}"
+
+- name: Run createdefaultpages to create the default pages for the site
+  django_manage:
+    command: createdefaultpages
     app_path: "{{ django_dir }}"
     virtualenv: "{{ virtualenv_path }}"
 
@@ -18,7 +30,7 @@
     owner: "{{ custom_user }}"
     group: www-data
     mode: 0774
-    
+
 - name: Create the images subdirectory if one does not exist
   file:
     path: "{{ django_dir }}media/images"
@@ -26,7 +38,7 @@
     owner: "{{ custom_user }}"
     group: www-data
     mode: 0774
-    
+
 - name: Create the original_images subdirectory if one does not exist
   file:
     path: "{{ django_dir }}media/original_images"

--- a/roles/wagtail/wagtail_setup/tasks/django_setup.yml
+++ b/roles/wagtail/wagtail_setup/tasks/django_setup.yml
@@ -11,12 +11,6 @@
     app_path: "{{ django_dir }}"
     virtualenv: "{{ virtualenv_path }}"
 
-- name: Run createdefaultpages to create the default pages for the site
-  django_manage:
-    command: createdefaultpages
-    app_path: "{{ django_dir }}"
-    virtualenv: "{{ virtualenv_path }}"
-
 - name: Gather all static files and place in single directory
   django_manage:
     command: collectstatic

--- a/roles/wagtail/wagtail_setup/tasks/main.yml
+++ b/roles/wagtail/wagtail_setup/tasks/main.yml
@@ -14,8 +14,6 @@
 
 # Setup database user with correct privileges and password
 - include_tasks: django_postgres_setup.yml
-  become: true
-  become_user: postgres
 
 # Run migrate on the database and make sure directories necessary for static content and media exist
 - include_tasks: django_setup.yml
@@ -33,16 +31,16 @@
     env: yes
     user: "{{ db_user }}"
     value: /usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-    
+
 # Create the cron job that regularly backs up the postgres database
 # See the README for further information on how this works
 - include_role:
     name: common/postgres/postgres_backup_cron
-    
+
 # The role that installs S3 and creates a default object storage bucket
 - include_role:
     name: common/s3
-    
+
 # The role that writes the postgres_recover_backup.sh from template. See README for more details.
 - include_role:
     name: common/postgres/postgres_setup_recovery

--- a/roles/wagtail/wagtail_setup/vars/main.yml
+++ b/roles/wagtail/wagtail_setup/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 git_clone_address: https://github.com/IATI/preview-website.git
 
-git_clone_branch: setup-wagtail
+git_clone_branch: alpha-deployment
 
 user_home_dir: /home/{{ custom_user }}/
 
@@ -44,7 +44,7 @@ apache2_directories:
     file_location: 404.html
     alias_source: /404
     alias_destination: /home/iati-website/preview-site/iati/iati/templates/404.html
-    
+
 apache2_errordocs:
   - error_code: 403
     error_template: /404

--- a/roles/wagtail/wagtail_setup/vars/main.yml
+++ b/roles/wagtail/wagtail_setup/vars/main.yml
@@ -37,13 +37,13 @@ apache2_directories:
   - root: /home/iati-website/preview-site/iati/iati
     file_location: wsgi.py
   - root: /home/iati-website/preview-site/iati/iati/templates/
-    file_location: 500.html
+    file_location: 500-static.html
     alias_source: /500
-    alias_destination: /home/iati-website/preview-site/iati/iati/templates/500.html
+    alias_destination: /home/iati-website/preview-site/iati/iati/templates/500-static.html
   - root: /home/iati-website/preview-site/iati/iati/templates/
-    file_location: 404.html
+    file_location: 404-static.html
     alias_source: /404
-    alias_destination: /home/iati-website/preview-site/iati/iati/templates/404.html
+    alias_destination: /home/iati-website/preview-site/iati/iati/templates/404-static.html
 
 apache2_errordocs:
   - error_code: 403


### PR DESCRIPTION
The changes necessary to deploy the alpha.

- append `_translation` to the migrate and makemigration commands
- Add the `createdefaultpages` command
- Something must have changed with either Ansible or psycopg2. The `postgresql_privs` command in `django_postgres_setup.yml` refused to run, giving the following error until I moved the `become_user: postgres` flag inside these commands specifically: `FATAL:  Peer authentication failed for user "postgres"`