### PR TITLE
Cronjob to update stats once a week

### DIFF
--- a/roles/wagtail/wagtail_setup/tasks/django_setup.yml
+++ b/roles/wagtail/wagtail_setup/tasks/django_setup.yml
@@ -46,3 +46,20 @@
     owner: "{{ custom_user }}"
     group: www-data
     mode: 0774
+
+- name: Create periodic update schell script from tmeplate
+  template:
+     src: periodic_updates.sh.j2
+     dest: "/usr/local/bin/periodic_updates.sh"
+     mode: 0775
+     owner: "{{ custom_user }}"
+     group: "{{ custom_user }}"
+
+- name: Set the periodic update shell script to run as a cronjob
+  cron:
+    user: "{{ custom_user }}"
+    name: "Periodic django update"
+    minute: "{{ update_minute }}"
+    hour: "{{ update_hour }}"
+    weekday: "{{ update_weekday }}"
+    job: "/usr/local/bin/periodic_updates.sh"

--- a/roles/wagtail/wagtail_setup/tasks/django_setup.yml
+++ b/roles/wagtail/wagtail_setup/tasks/django_setup.yml
@@ -47,7 +47,7 @@
     group: www-data
     mode: 0774
 
-- name: Create periodic update schell script from tmeplate
+- name: Create periodic update schell script from template
   template:
      src: periodic_updates.sh.j2
      dest: "/usr/local/bin/periodic_updates.sh"

--- a/roles/wagtail/wagtail_setup/templates/periodic_updates.sh.js
+++ b/roles/wagtail/wagtail_setup/templates/periodic_updates.sh.js
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Change directory to django application
+cd {{ django_dir }}
+
+# Source the virtual environment
+source {{ virtualenv_path }}/bin/activate
+
+# Update the statistics
+./manage.py updatestatistics

--- a/roles/wagtail/wagtail_setup/vars/main.yml
+++ b/roles/wagtail/wagtail_setup/vars/main.yml
@@ -96,3 +96,9 @@ s3_bucket_name: "iatibucket"
 s3_bucket_host: "s3.amazonaws.com"
 
 s3_bucket_region: "ca-central-1"
+
+update_minute: 0
+
+update_hour: 0
+
+update_weekday: 0


### PR DESCRIPTION
To be merged after: https://github.com/IATI/preview-website/pull/140

Writes a shellscript that runs `./manage.py updatestatistics` once per week every Sunday at midnight.

I left the name ambiguous as `periodic-updates` should we decide to also include `./manage.py publish_scheduled_pages` in this shell script in the future to enable scheduled publishing for CMS users, or if we desire to change the periodicity. 