### PR TITLE
Deploy iatistandard.org from master

### DIFF
--- a/roles/wagtail/wagtail_setup/vars/main.yml
+++ b/roles/wagtail/wagtail_setup/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 git_clone_address: https://github.com/IATI/preview-website.git
 
-git_clone_branch: add-page-models
+git_clone_branch: master
 
 user_home_dir: /home/{{ custom_user }}/
 


### PR DESCRIPTION
Changes the git branch to `master` given this issues around our gitflow approach to working on that project have been resolved.