### PR TITLE
Fix redeploy errors

### DIFF
--- a/roles/common/apache2/apache2_install/vars/main.yml
+++ b/roles/common/apache2/apache2_install/vars/main.yml
@@ -9,3 +9,4 @@ apache2_conf_destination: /etc/apache2/sites-available/000-default.conf
 apache2_modules:
   - headers
   - rewrite
+  - ssl

--- a/roles/wagtail/wagtail_setup/tasks/main.yml
+++ b/roles/wagtail/wagtail_setup/tasks/main.yml
@@ -19,10 +19,10 @@
 # Run migrate on the database and make sure directories necessary for static content and media exist
 - include_tasks: django_setup.yml
 
-- include_tasks: ssl_setup.yml
-
 - include_role:
     name: common/apache2/apache2_install
+
+- include_tasks: ssl_setup.yml
 
 - include_role:
     name: common/apache2/apache2_restart

--- a/roles/wagtail/wagtail_setup/tasks/ssl_setup.yml
+++ b/roles/wagtail/wagtail_setup/tasks/ssl_setup.yml
@@ -34,8 +34,3 @@
     privatekey_path: "{{ ssl_key_path }}"
     csr_path: "{{ ssl_sign_request_path }}"
     provider: selfsigned
-
-- name: Enable SSL in Apache2
-  apache2_module:
-    state: present
-    name: ssl

--- a/roles/wagtail/wagtail_setup/templates/postgres_backup.sh.j2
+++ b/roles/wagtail/wagtail_setup/templates/postgres_backup.sh.j2
@@ -13,4 +13,4 @@ cp -r {{ django_dir }}media {{ backup_directory }}
 tar -czf backup.tar.gzip {{ backup_directory }}
 
 # Write the file to a timestamped location via the s3 object storage service
-s3cmd -c /home/{{ custom_user }}/.s3cfg --no-progress put backup.tar.gzip s3://{{ s3_bucket_name }}/$(date +\%Y-\%m-\%d).tar.gz
+s3cmd -c /root/.s3cfg --no-progress put backup.tar.gzip s3://{{ s3_bucket_name }}/$(date +\%Y-\%m-\%d).tar.gz


### PR DESCRIPTION
Cherry-picked fixes from `test-dev` branch needed to deploy onto brand new server.

Had to rearrange order of Apache2/SSL deployment, and also found a small error on the s3cmd setup that prevented meaningful backups from being created.